### PR TITLE
Add debugging support with configurable debug environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Feature: Greeting
 
 ## Debugging
 
-The extension supports debugging tests through the VS Code testing panel. When you click the debug button for a test, it will run with the `PWDEBUG=1` environment variable set, which enables Playwright's debug mode (if you're using Playwright). This allows you to:
+The extension supports debugging tests through the VS Code testing panel. When you click the debug button for a test, it will run with environment variables defined in `cucumber_runner.debug_env_variables`, which by default sets `PWDEBUG=1` to enable Playwright's debug mode (if you're using Playwright). This allows you to:
 
 - Step through your test execution
 - Inspect the browser state
@@ -73,5 +73,17 @@ Example:
 ```json
 {
   "cucumber_runner.cucumber_path": "./node_modules/.bin/cucumber-js"
+}
+```
+
+The `cucumber_runner.debug_env_variables` setting defines environment variables that will be passed to the `cucumber-js` command when debugging tests. By default, it sets `PWDEBUG=1` for Playwright Inspector support.
+
+Example:
+
+```json
+{
+  "cucumber_runner.debug_env_variables": {
+    "PWDEBUG": "1"
+  }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Feature: Greeting
     Then I should have heard "hello"
 ```
 
+## Debugging
+
+The extension supports debugging tests through the VS Code testing panel. When you click the debug button for a test, it will run with the `PWDEBUG=1` environment variable set, which enables Playwright's debug mode (if you're using Playwright). This allows you to:
+
+- Step through your test execution
+- Inspect the browser state
+- Use Playwright Inspector for debugging
+
+Simply click the debug icon (instead of the run icon) next to any test in the VS Code testing panel.
+
 ## Extension Settings
 
 The `cucumber_runner.features` setting defines where the extension should look for `.feature` files.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ Feature: Greeting
 
 ## Debugging
 
-The extension supports debugging tests through the VS Code testing panel. When you click the debug button for a test, it will run with environment variables defined in `cucumber_runner.debug_env_variables`, which by default sets `PWDEBUG=1` to enable Playwright's debug mode (if you're using Playwright). This allows you to:
-
-- Step through your test execution
-- Inspect the browser state
-- Use Playwright Inspector for debugging
+The extension supports debugging tests through the VS Code testing panel. When you click the debug button for a test, it will run with environment variables defined in `cucumber_runner.debug_env_variables`. This allows you for example to use Playwright Inspector for debugging ( `PWDEBUG=1` ) to step through your test execution or inspect your browser state.
 
 Simply click the debug icon (instead of the run icon) next to any test in the VS Code testing panel.
 
@@ -51,6 +47,19 @@ Example:
 }
 ```
 
+The `cucumber_runner.debug_env_variables` setting defines environment variables that will be passed to the `cucumber-js` command when debugging tests.
+
+Example:
+
+```json
+{
+  "cucumber_runner.debug_env_variables": {
+    "PWDEBUG": "1"
+  }
+}
+```
+
+
 The `cucumber_runner.cli_options` setting defines options that will be passed to the `cucumber-js` command.
 
 Example:
@@ -73,17 +82,5 @@ Example:
 ```json
 {
   "cucumber_runner.cucumber_path": "./node_modules/.bin/cucumber-js"
-}
-```
-
-The `cucumber_runner.debug_env_variables` setting defines environment variables that will be passed to the `cucumber-js` command when debugging tests.
-
-Example:
-
-```json
-{
-  "cucumber_runner.debug_env_variables": {
-    "PWDEBUG": "1"
-  }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Example:
 }
 ```
 
-The `cucumber_runner.debug_env_variables` setting defines environment variables that will be passed to the `cucumber-js` command when debugging tests. By default, it sets `PWDEBUG=1` for Playwright Inspector support.
+The `cucumber_runner.debug_env_variables` setting defines environment variables that will be passed to the `cucumber-js` command when debugging tests.
 
 Example:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-cucumber-js-runner",
-	"version": "1.89.1",
+	"version": "1.89.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-cucumber-js-runner",
-			"version": "1.89.1",
+			"version": "1.89.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^20.14.8",

--- a/package.json
+++ b/package.json
@@ -56,11 +56,10 @@
 					"default": "./node_modules/.bin/cucumber-js"
 				},
 				"cucumber_runner.debug_env_variables": {
-					"markdownDescription": "The `cucumber_runner.debug_env_variables` setting defines environment variables that will be passed to the `cucumber-js` command when debugging.\nDefault value:\n```json\n{\n  \"cucumber_runner.debug_env_variables\": {\n    \"PWDEBUG\": \"1\"\n  }\n}\n```",
+					"markdownDescription": "The `cucumber_runner.debug_env_variables` setting defines environment variables that will be passed to the `cucumber-js` command when debugging.\nSample:\n```json\n{\n  \"cucumber_runner.debug_env_variables\": {\n    \"PWDEBUG\": \"1\"\n  }\n}\n```\nDefault value:\n```json\n{\n  \"cucumber_runner.debug_env_variables\": {}\n}\n```",
 					"type": "object",
 					"required": false,
 					"default": {
-						"PWDEBUG": "1"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,14 @@
 					"type": "string",
 					"required": false,
 					"default": "./node_modules/.bin/cucumber-js"
+				},
+				"cucumber_runner.debug_env_variables": {
+					"markdownDescription": "The `cucumber_runner.debug_env_variables` setting defines environment variables that will be passed to the `cucumber-js` command when debugging.\nDefault value:\n```json\n{\n  \"cucumber_runner.debug_env_variables\": {\n    \"PWDEBUG\": \"1\"\n  }\n}\n```",
+					"type": "object",
+					"required": false,
+					"default": {
+						"PWDEBUG": "1"
+					}
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -56,11 +56,10 @@
 					"default": "./node_modules/.bin/cucumber-js"
 				},
 				"cucumber_runner.debug_env_variables": {
-					"markdownDescription": "The `cucumber_runner.debug_env_variables` setting defines environment variables that will be passed to the `cucumber-js` command when debugging.\nSample:\n```json\n{\n  \"cucumber_runner.debug_env_variables\": {\n    \"PWDEBUG\": \"1\"\n  }\n}\n```\nDefault value:\n```json\n{\n  \"cucumber_runner.debug_env_variables\": {}\n}\n```",
+					"markdownDescription": "The `cucumber_runner.debug_env_variables` setting defines environment variables that will be passed to the `cucumber-js` command when debugging.\nDefault value:\n```json\n{\n  \"cucumber_runner.debug_env_variables\": {}\n}\n```",
 					"type": "object",
 					"required": false,
-					"default": {
-					}
+					"default": {}
 				}
 			}
 		}

--- a/src/configuration/getExtensionConfiguration.ts
+++ b/src/configuration/getExtensionConfiguration.ts
@@ -1,11 +1,12 @@
 import * as vscode from "vscode";
 
-export function getExtensionConfiguration(): { featurePaths: string[], env: { [key: string]: string }, cliOptions: string[], cucumberPath: string } {
+export function getExtensionConfiguration(): { featurePaths: string[], env: { [key: string]: string }, cliOptions: string[], cucumberPath: string, debugEnv: { [key: string]: string } } {
     const configuration = vscode.workspace.getConfiguration('cucumber_runner');
     return {
         featurePaths: configuration.get<string[]>('features')!,
         env: configuration.get<{ [key: string]: string }>('env_variables')!,
         cliOptions: configuration.get<string[]>('cli_options')!,
         cucumberPath: configuration.get<string>('cucumber_path')!,
+        debugEnv: configuration.get<{ [key: string]: string }>('debug_env_variables')!,
     }
 }

--- a/src/cucumber/CucumberRunner.ts
+++ b/src/cucumber/CucumberRunner.ts
@@ -31,12 +31,12 @@ export class CucumberRunner {
     private static spawnCucumberProcess(testRun: vscode.TestRun, scenarioName: string, debug?: boolean): ChildProcessWithoutNullStreams {
         const cwd = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0].uri.path;
         const scenarioNameRegexed = `^${scenarioName.replace(/([.+*?^$()[\]{}|\\])/g, '\\$1')}$`;
-        const { featurePaths, env, cliOptions, cucumberPath } = getExtensionConfiguration();
+        const { featurePaths, env, cliOptions, cucumberPath, debugEnv } = getExtensionConfiguration();
         const nodeArguments = [cucumberPath, ...featurePaths, '--name', scenarioNameRegexed, ...cliOptions];
 
         this.log(testRun,
             'Executing command: '
-            + (debug ? 'PWDEBUG=1 ' : '')
+            + (debug && Object.keys(debugEnv).length ? `${Object.keys(debugEnv).map(vr => vr + '=......').join(' ')} ` : '')
             + (Object.keys(env).length ? `${Object.keys(env).map(vr => vr + '=......').join(' ')} ` : '')
             + 'node '
             + [cucumberPath, ...featurePaths, '--name', `"${scenarioNameRegexed}"`, ...cliOptions].join(' ')
@@ -49,7 +49,7 @@ export class CucumberRunner {
                 cwd: cwd,
                 env: {
                     ...process.env, ...env,
-                    ...(debug && { 'PWDEBUG': '1' }),
+                    ...(debug && debugEnv),
                 },
             }
         );

--- a/src/cucumber/CucumberRunner.ts
+++ b/src/cucumber/CucumberRunner.ts
@@ -36,7 +36,7 @@ export class CucumberRunner {
 
         this.log(testRun,
             'Executing command: '
-            // + (debug ? 'DEBUG=cucumber ' : '')
+            + (debug ? 'PWDEBUG=1 ' : '')
             + (Object.keys(env).length ? `${Object.keys(env).map(vr => vr + '=......').join(' ')} ` : '')
             + 'node '
             + [cucumberPath, ...featurePaths, '--name', `"${scenarioNameRegexed}"`, ...cliOptions].join(' ')
@@ -49,7 +49,7 @@ export class CucumberRunner {
                 cwd: cwd,
                 env: {
                     ...process.env, ...env,
-                    // ...(debug && { 'DEBUG': 'cucumber' }),
+                    ...(debug && { 'PWDEBUG': '1' }),
                 },
             }
         );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,10 +12,15 @@ export async function activate(context: vscode.ExtensionContext) {
 	};
 
 	const runHandler = (request: vscode.TestRunRequest, token: vscode.CancellationToken) => {
-		startTestRun(testController, request, token);
+		startTestRun(testController, request, token, false);
+	};
+
+	const debugHandler = (request: vscode.TestRunRequest, token: vscode.CancellationToken) => {
+		startTestRun(testController, request, token, true);
 	};
 
 	testController.createRunProfile('Run Tests', vscode.TestRunProfileKind.Run, runHandler, true, undefined, false);
+	testController.createRunProfile('Debug Tests', vscode.TestRunProfileKind.Debug, debugHandler, true, undefined, false);
 
 	const fileChangedEmitter = new vscode.EventEmitter<vscode.Uri>();
 

--- a/src/functions/startTestRun.ts
+++ b/src/functions/startTestRun.ts
@@ -4,7 +4,7 @@ import TestCase from '../testTree/TestCase';
 import TestFile from '../testTree/TestFile';
 import { testItemDataMap } from '../other';
 
-export const startTestRun = async (controller: vscode.TestController, request: vscode.TestRunRequest, token: vscode.CancellationToken) => {
+export const startTestRun = async (controller: vscode.TestController, request: vscode.TestRunRequest, token: vscode.CancellationToken, debug: boolean = false) => {
     const testRun = controller.createTestRun(request);
 
     token.onCancellationRequested(() => {
@@ -52,7 +52,7 @@ export const startTestRun = async (controller: vscode.TestController, request: v
 
     async function runTest(testCase: TestCase): Promise<string[]> {
         testRun.appendOutput(`Running test: ${testCase.name}\r\n`);
-        const cucumberOutput = await CucumberRunner.runTest(testRun, testCase.name);
+        const cucumberOutput = await CucumberRunner.runTest(testRun, testCase.name, debug);
         if (!token.isCancellationRequested) {
             testRun.appendOutput('Finished running test!\r\n\n');
         }


### PR DESCRIPTION
This allows e.g. to set `PWDEBUG=1` for playwright runners to step through the code.